### PR TITLE
build: replace FetchContent with find_package

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install CMake
         uses: lukka/get-cmake@v3.25.2
       - name: Install Project Dependencies
-        run: sudo apt install -y gtest sdl2 sdl2-image
+        run: sudo apt install -y libgtest-dev libsdl2-dev libsdl2-image-dev
       - name: Create directory for build
         run: mkdir build
       - name: Create build files

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,19 +14,16 @@ jobs:
         with:
           submodules: 'true'
       - name: Install CMake
-        uses: lukka/get-cmake@v3.25.2
-      - name: Install Project Dependencies
-        run: sudo apt install -y libgtest-dev libsdl2-dev libsdl2-image-dev
-      - name: Create directory for build
-        run: mkdir build
-      - name: Create build files
-        working-directory: ./build
-        run: cmake ..
-      - name: Build project
-        working-directory: ./build 
-        run: make
-      - name: Run tests
-        working-directory: ./build 
-        run: ctest
+        uses: lukka/get-cmake@v3.21.2
+      - name: Setup vcpkg for dependencies
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: 53bef8994c541b6561884a8395ea35715ece75db 
+      - name: Run CMake
+        uses: lukka/run-cmake@v10
+        with: 
+          configurePreset: ninja-multi-vcpkg
+          buildPreset: ninja-multi-vcpkg
+          testPreset: ninja-multi-vcpkg
 
       

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with: 
           configurePreset: ubuntu-runner-config
-          buildPreset: ubuntu-runner-config
-          testPreset: ubuntu-runner-config
+          buildPreset: ubuntu-runner-debug
+          testPreset: ubuntu-runner-test
 
       

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,8 @@ jobs:
           submodules: 'true'
       - name: Install CMake
         uses: lukka/get-cmake@v3.25.2
+      - name: Install Project Dependencies
+        run: sudo apt install -y gtest sdl2 sdl2-image
       - name: Create directory for build
         run: mkdir build
       - name: Create build files

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Run CMake
         uses: lukka/run-cmake@v10
         with: 
-          configurePreset: ninja-multi-vcpkg
-          buildPreset: ninja-multi-vcpkg
-          testPreset: ninja-multi-vcpkg
+          configurePreset: ubuntu-runner-config
+          buildPreset: ubuntu-runner-config
+          testPreset: ubuntu-runner-config
 
       

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 CMakeLists.txt.user
 CMakeCache.txt
-CMakePresets.json
 CMakeFiles
 CMakeScripts
 Testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,6 @@ add_subdirectory(lib)
 enable_testing()
 add_subdirectory(tests)
 
-set(SDL2IMAGE_INSTALL OFF)
-set(BUILD_SHARED_LIBS FALSE)
-
 #Include assets in output
 add_custom_target(assets
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/assets ${CMAKE_CURRENT_BINARY_DIR}/assets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,16 +17,10 @@ target_link_libraries(PongLib PRIVATE SDL2::SDL2 SDL2::SDL2main)
 target_link_libraries(Tests PRIVATE SDL2::SDL2 SDL2::SDL2main)
 
 #SDL_Image
-FetchContent_Declare(
-        SDL_Image
-        GIT_REPOSITORY https://github.com/libsdl-org/SDL_image.git
-        GIT_TAG d3c6d5963dbe438bcae0e2b6f3d7cfea23d02829
-        SYSTEM
-)
-
+find_package(SDL2_image)
+target_link_libraries(PongLib PRIVATE SDL2_image::SDL2_image)
 set(SDL2IMAGE_INSTALL OFF)
 set(BUILD_SHARED_LIBS FALSE)
-FetchContent_MakeAvailable(SDL_Image)
 
 #Include assets in output
 add_custom_target(assets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,15 +10,6 @@ add_subdirectory(lib)
 enable_testing()
 add_subdirectory(tests)
 
-#SDL2
-find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
-target_link_libraries(Pong PRIVATE SDL2::SDL2 SDL2::SDL2main)
-target_link_libraries(PongLib PRIVATE SDL2::SDL2 SDL2::SDL2main)
-target_link_libraries(Tests PRIVATE SDL2::SDL2 SDL2::SDL2main)
-
-#SDL_Image
-find_package(SDL2_image)
-target_link_libraries(PongLib PRIVATE SDL2_image::SDL2_image)
 set(SDL2IMAGE_INSTALL OFF)
 set(BUILD_SHARED_LIBS FALSE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,23 +10,11 @@ add_subdirectory(lib)
 enable_testing()
 add_subdirectory(tests)
 
-#googletest
-FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG v1.13.0
-        SYSTEM
-)
-FetchContent_MakeAvailable(googletest)
-
 #SDL2
-FetchContent_Declare(
-        SDL2
-        GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-        GIT_TAG release-2.26.4
-        SYSTEM
-)
-FetchContent_MakeAvailable(SDL2)
+find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
+target_link_libraries(Pong PRIVATE SDL2::SDL2 SDL2::SDL2main)
+target_link_libraries(PongLib PRIVATE SDL2::SDL2 SDL2::SDL2main)
+target_link_libraries(Tests PRIVATE SDL2::SDL2 SDL2::SDL2main)
 
 #SDL_Image
 FetchContent_Declare(
@@ -38,7 +26,6 @@ FetchContent_Declare(
 
 set(SDL2IMAGE_INSTALL OFF)
 set(BUILD_SHARED_LIBS FALSE)
-
 FetchContent_MakeAvailable(SDL_Image)
 
 #Include assets in output

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,70 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "ninja-multi-vcpkg",
+            "displayName": "Ninja Multi-Config",
+            "description": "Configure with vcpkg toolchain and generate Ninja project files for all configurations",
+            "binaryDir": "${sourceDir}/builds/${presetName}",
+            "generator": "Ninja Multi-Config",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": {
+                    "type": "FILEPATH",
+                    "value": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+                }
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "ninja-vcpkg-debug",
+            "configurePreset": "ninja-multi-vcpkg",
+            "displayName": "Build (Debug)",
+            "description": "Build with Ninja/vcpkg (Debug)",
+            "configuration": "Debug"
+        },
+        {
+            "name": "ninja-vcpkg-release",
+            "configurePreset": "ninja-multi-vcpkg",
+            "displayName": "Build (Release)",
+            "description": "Build with Ninja/vcpkg (Release)",
+            "configuration": "Release"
+        },
+        {
+            "name": "ninja-vcpkg",
+            "configurePreset": "ninja-multi-vcpkg",
+            "displayName": "Build",
+            "description": "Build with Ninja/vcpkg"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "test-ninja-vcpkg",
+            "configurePreset": "ninja-multi-vcpkg",
+            "hidden": true
+        },
+        {
+            "name": "test-debug",
+            "description": "Test (Debug)",
+            "displayName": "Test (Debug)",
+            "configuration": "Debug",
+            "inherits": [
+                "test-ninja-vcpkg"
+            ]
+        },
+        {
+            "name": "test-release",
+            "description": "Test (Release)",
+            "displayName": "Test (Release)",
+            "configuration": "Release",
+            "inherits": [
+                "test-ninja-vcpkg"
+            ]
+        }
+    ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,70 +1,91 @@
 {
-    "version": 3,
-    "cmakeMinimumRequired": {
-        "major": 3,
-        "minor": 21,
-        "patch": 0
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "ubuntu-runner-config",
+      "displayName": "Github Ubuntu Runner",
+      "description": "Package Manager: vcpkg; Generator: Ninja; Expects vcpkg in source dir",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja Multi-Config",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        }
+      }
     },
-    "configurePresets": [
-        {
-            "name": "ninja-multi-vcpkg",
-            "displayName": "Ninja Multi-Config",
-            "description": "Configure with vcpkg toolchain and generate Ninja project files for all configurations",
-            "binaryDir": "${sourceDir}/builds/${presetName}",
-            "generator": "Ninja Multi-Config",
-            "cacheVariables": {
-                "CMAKE_TOOLCHAIN_FILE": {
-                    "type": "FILEPATH",
-                    "value": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-                }
-            }
+    {
+      "name": "dev-vcpkg-ninja",
+      "displayName": "Windows (vcpkg/Ninja)",
+      "description": "Package Manager: vcpkg; Generator: Ninja; Uses %VCPKG_ROOT%",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja Multi-Config",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "FILEPATH",
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
         }
-    ],
-    "buildPresets": [
-        {
-            "name": "ninja-vcpkg-debug",
-            "configurePreset": "ninja-multi-vcpkg",
-            "displayName": "Build (Debug)",
-            "description": "Build with Ninja/vcpkg (Debug)",
-            "configuration": "Debug"
-        },
-        {
-            "name": "ninja-vcpkg-release",
-            "configurePreset": "ninja-multi-vcpkg",
-            "displayName": "Build (Release)",
-            "description": "Build with Ninja/vcpkg (Release)",
-            "configuration": "Release"
-        },
-        {
-            "name": "ninja-vcpkg",
-            "configurePreset": "ninja-multi-vcpkg",
-            "displayName": "Build",
-            "description": "Build with Ninja/vcpkg"
-        }
-    ],
-    "testPresets": [
-        {
-            "name": "test-ninja-vcpkg",
-            "configurePreset": "ninja-multi-vcpkg",
-            "hidden": true
-        },
-        {
-            "name": "test-debug",
-            "description": "Test (Debug)",
-            "displayName": "Test (Debug)",
-            "configuration": "Debug",
-            "inherits": [
-                "test-ninja-vcpkg"
-            ]
-        },
-        {
-            "name": "test-release",
-            "description": "Test (Release)",
-            "displayName": "Test (Release)",
-            "configuration": "Release",
-            "inherits": [
-                "test-ninja-vcpkg"
-            ]
-        }
-    ]
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "build-debug",
+      "displayName": "Build (Debug)",
+      "description": "Build Debug",
+      "configuration": "Debug",
+      "hidden": true
+    },
+    {
+      "name": "build-release",
+      "displayName": "Build (Release)",
+      "description": "Build Release",
+      "configuration": "Release",
+      "hidden": true
+    },
+    {
+      "name": "ubuntu-runner-debug",
+      "configurePreset": "ubuntu-runner-config",
+      "inherits": [ "build-debug" ]
+    },
+    {
+      "name": "ubuntu-runner-release",
+      "configurePreset": "ubuntu-runner-config",
+      "inherits": [ "build-release" ]
+    },
+    {
+      "name": "dev-vcpkg-debug",
+      "configurePreset": "dev-vcpkg-ninja",
+      "inherits": [ "build-debug" ]
+    },
+    {
+      "name": "dev-vcpkg-release",
+      "configurePreset": "dev-vcpkg-ninja",
+      "inherits": [ "build-release" ]
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "test",
+      "description": "Test",
+      "displayName": "Test",
+      "configuration": "Debug",
+      "hidden": true
+    },
+    {
+      "name": "ubuntu-runner-test",
+      "configurePreset": "ubuntu-runner-config",
+      "inherits": [ "test" ]
+    },
+    {
+      "name": "dev-vcpkg-test",
+      "configurePreset": "dev-vcpkg-ninja",
+      "inherits": ["test"]
+    }
+  ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "dev-vcpkg-ninja",
-      "displayName": "Windows (vcpkg/Ninja)",
+      "displayName": "Development with Ninja + vcpkg",
       "description": "Package Manager: vcpkg; Generator: Ninja; Uses %VCPKG_ROOT%",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "generator": "Ninja Multi-Config",

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,14 +1,6 @@
 add_executable(Pong 
     "src/main.cpp")
 
-if (WIN32)
-    add_custom_command(
-        TARGET Pong POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:SDL2::SDL2>" "$<TARGET_FILE_DIR:Pong>"
-        VERBATIM
-    )
-endif()
-
 find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
 
 target_link_libraries(Pong 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(Pong 
     "src/main.cpp")
 
-find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
+find_package(SDL2 REQUIRED CONFIG)
 
 target_link_libraries(Pong 
 	PRIVATE

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -6,6 +6,6 @@ find_package(SDL2 REQUIRED CONFIG)
 target_link_libraries(Pong 
 	PRIVATE
 	PongLib 
-	SDL2::SDL2 
-	SDL2::SDL2main
+	$<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
+	$<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
 )

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -12,4 +12,4 @@ endif()
 target_link_libraries(Pong 
 	PRIVATE
 	PongLib 
-	SDL2_image::SDL2_image-static)
+)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -9,7 +9,11 @@ if (WIN32)
     )
 endif()
 
+find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
+
 target_link_libraries(Pong 
 	PRIVATE
 	PongLib 
+	SDL2::SDL2 
+	SDL2::SDL2main
 )

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -9,4 +9,7 @@ if (WIN32)
     )
 endif()
 
-target_link_libraries(Pong PRIVATE PongLib SDL2::SDL2-static SDL2main SDL2_image::SDL2_image-static)
+target_link_libraries(Pong 
+	PRIVATE
+	PongLib 
+	SDL2_image::SDL2_image-static)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(PongLib STATIC
     "src/physics/collision_system.cpp")
 
 find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
-find_package(SDL2_image)
+find_package(SDL2_image REQUIRED)
 
 target_include_directories(PongLib PUBLIC 
     "includes/")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,4 +17,8 @@ add_library(PongLib STATIC
 
 target_include_directories(PongLib PUBLIC 
     "includes/")
-target_link_libraries(PongLib PRIVATE SDL2::SDL2-static SDL2_image::SDL2_image-static)
+
+target_link_libraries(PongLib 
+	PRIVATE
+	SDL2_image::SDL2_image-static
+)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,7 +16,19 @@ add_library(PongLib STATIC
     "src/physics/collision_system.cpp")
 
 find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
-find_package(SDL2_image REQUIRED)
+find_package(SDL2_image)
+
+if(${SDL2_image_FOUND})
+	target_link_libraries(PongLib PRIVATE SDL2_image::SDL2_image)
+else()
+	#In case package manager only finds older version of SDL2_image that does
+	#not include a cmake.config (for example the Github Ubuntu Workflow Runner...)
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(SDL2_image REQUIRED SDL2_image)
+	target_link_libraries(PongLib PRIVATE ${SDL2_image_LIBRARIES})
+	target_include_directories(PongLib PRIVATE ${SDL2_image_INCLUDE_DIRS})
+	target_compile_options(PongLib PRIVATE ${SDL2_image_CFLAGS_OTHER})
+endif()
 
 target_include_directories(PongLib PUBLIC 
     "includes/")
@@ -24,5 +36,4 @@ target_include_directories(PongLib PUBLIC
 target_link_libraries(PongLib 
 	PRIVATE
 	SDL2::SDL2
-	SDL2_image::SDL2_image
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,6 +15,14 @@ add_library(PongLib STATIC
     "src/physics/collision_eventprocessor.cpp"
     "src/physics/collision_system.cpp")
 
+find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
+find_package(SDL2_image)
+
 target_include_directories(PongLib PUBLIC 
     "includes/")
 
+target_link_libraries(PongLib 
+	PRIVATE
+	SDL2::SDL2
+	SDL2_image::SDL2_image
+)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(PongLib STATIC
     "src/physics/collision_system.cpp")
 
 find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
-find_package(SDL2_image)
+find_package(SDL2_image REQUIRED)
 
 target_include_directories(PongLib PUBLIC 
     "includes/")
@@ -24,4 +24,5 @@ target_include_directories(PongLib PUBLIC
 target_link_libraries(PongLib 
 	PRIVATE
 	SDL2::SDL2
+    SDL2_image::SDL2_image
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,7 +18,3 @@ add_library(PongLib STATIC
 target_include_directories(PongLib PUBLIC 
     "includes/")
 
-target_link_libraries(PongLib 
-	PRIVATE
-	SDL2_image::SDL2_image-static
-)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,6 +23,7 @@ target_include_directories(PongLib PUBLIC
 
 target_link_libraries(PongLib 
 	PRIVATE
-	SDL2::SDL2
-  SDL2_image::SDL2_image
+	$<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
+	$<IF:$<TARGET_EXISTS:SDL2_image::SDL2_image>,SDL2_image::SDL2_image,SDL2_image::SDL2_image-static>
 )
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,18 +18,6 @@ add_library(PongLib STATIC
 find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
 find_package(SDL2_image)
 
-if(${SDL2_image_FOUND})
-	target_link_libraries(PongLib PRIVATE SDL2_image::SDL2_image)
-else()
-	#In case package manager only finds older version of SDL2_image that does
-	#not include a cmake.config (for example the Github Ubuntu Workflow Runner...)
-	find_package(PkgConfig REQUIRED)
-	pkg_check_modules(SDL2_image REQUIRED SDL2_image)
-	target_link_libraries(PongLib PRIVATE ${SDL2_image_LIBRARIES})
-	target_include_directories(PongLib PRIVATE ${SDL2_image_INCLUDE_DIRS})
-	target_compile_options(PongLib PRIVATE ${SDL2_image_CFLAGS_OTHER})
-endif()
-
 target_include_directories(PongLib PUBLIC 
     "includes/")
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(PongLib STATIC
     "src/physics/collision_eventprocessor.cpp"
     "src/physics/collision_system.cpp")
 
-find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
+find_package(SDL2 REQUIRED CONFIG)
 find_package(SDL2_image REQUIRED)
 
 target_include_directories(PongLib PUBLIC 
@@ -24,5 +24,5 @@ target_include_directories(PongLib PUBLIC
 target_link_libraries(PongLib 
 	PRIVATE
 	SDL2::SDL2
-    SDL2_image::SDL2_image
+  SDL2_image::SDL2_image
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,10 +15,18 @@ add_executable(Tests
 
 target_include_directories(Tests PRIVATE includes/)
 
+#googletest
+FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.13.0
+        SYSTEM
+)
+FetchContent_MakeAvailable(googletest)
+
 target_link_libraries(Tests 
-	PRIVATE PongLib 
-	SDL2::SDL2-static 
-	SDL2_image::SDL2_image-static 
+	PRIVATE
+	PongLib 
 	GTest::gtest_main gmock_main
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(Tests
 
 target_include_directories(Tests PRIVATE includes/)
 
-find_package(GTest)
+find_package(GTest REQUIRED)
 find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
 
 target_link_libraries(Tests 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,6 @@ target_link_libraries(Tests
 	PRIVATE
 	PongLib 
 	SDL2::SDL2
-	GTest::gtest_main gmock_main
+	GTest::gtest_main
 )
 gtest_discover_tests(Tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(Tests
 target_include_directories(Tests PRIVATE includes/)
 
 find_package(GTest REQUIRED)
-find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
+find_package(SDL2 REQUIRED CONFIG)
 
 target_link_libraries(Tests 
 	PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,12 +15,13 @@ add_executable(Tests
 
 target_include_directories(Tests PRIVATE includes/)
 
-#googletest
 find_package(GTest)
+find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2 SDL2main)
 
 target_link_libraries(Tests 
 	PRIVATE
 	PongLib 
+	SDL2::SDL2
 	GTest::gtest_main gmock_main
 )
 gtest_discover_tests(Tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(SDL2 REQUIRED CONFIG)
 target_link_libraries(Tests 
 	PRIVATE
 	PongLib 
-	SDL2::SDL2
 	GTest::gtest_main
+	$<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
 )
 gtest_discover_tests(Tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,19 +16,11 @@ add_executable(Tests
 target_include_directories(Tests PRIVATE includes/)
 
 #googletest
-FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG v1.13.0
-        SYSTEM
-)
-FetchContent_MakeAvailable(googletest)
+find_package(GTest)
 
 target_link_libraries(Tests 
 	PRIVATE
 	PongLib 
 	GTest::gtest_main gmock_main
 )
-
-include(GoogleTest)
 gtest_discover_tests(Tests)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,14 @@
+{
+	"builtin-baseline": "53bef8994c541b6561884a8395ea35715ece75db",
+	"dependencies": [
+		{
+			"name": "sdl2"
+		},
+		{
+			"name": "sdl2-image"
+		},
+		{
+			"name": "gtest"
+		}
+	]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,14 +1,8 @@
 {
 	"builtin-baseline": "53bef8994c541b6561884a8395ea35715ece75db",
 	"dependencies": [
-		{
-			"name": "sdl2"
-		},
-		{
-			"name": "sdl2-image"
-		},
-		{
-			"name": "gtest"
-		}
+		"sdl2",
+		"sdl2-image",
+		"gtest"
 	]
 }


### PR DESCRIPTION
Replaced FetchContent with find_package so you don't need to build SDL and stuff yourself.

On Linux it works with builtin package manager.
On Windows, I tried it out with vcpkg and it worked fine.